### PR TITLE
Improvement for multiprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ __pycache__
 venv
 *.pyc
 .venv
-.coverage
+.coverage*
 htmlcov
 .eggs

--- a/krbticket/command.py
+++ b/krbticket/command.py
@@ -1,3 +1,4 @@
+import fasteners
 import logging
 import os
 import subprocess
@@ -77,4 +78,5 @@ class KrbCommand():
             custom_env["LC_ALL"] = "C"
             return subprocess.check_output(commands, universal_newlines=True, env=custom_env)
 
-        return retriable_call()
+        with fasteners.InterProcessLock(config.ccache_cmd_lockfile):
+            return retriable_call()

--- a/krbticket/config.py
+++ b/krbticket/config.py
@@ -31,6 +31,8 @@ class KrbConfig():
         self.updater_class = updater_class
         self.retry_options = retry_options
         self.ccache_name = ccache_name if ccache_name else self._ccache_name()
+        self.ccache_lockfile = '{}.krbticket.lock'.format(self.ccache_name)
+        self.ccache_cmd_lockfile = '{}.krbticket.cmd.lock'.format(self.ccache_name)
 
     def __str__(self):
         super_str = super(KrbConfig, self).__str__()
@@ -58,14 +60,6 @@ class KrbConfig():
 
     def _default_ccache_name(self):
         return os.environ.get('KRB5CCNAME', '/tmp/krb5cc_{}'.format(os.getuid()))
-
-    @property
-    def ccache_lockfile(self):
-        return '{}.krbticket.lock'.format(self.ccache_name)
-
-    @property
-    def ccache_cmd_lockfile(self):
-        return '{}.krbticket.cmd.lock'.format(self.ccache_name)
 
     def _per_process_ccache_name(self):
         if self._is_main_process():

--- a/krbticket/config.py
+++ b/krbticket/config.py
@@ -63,6 +63,10 @@ class KrbConfig():
     def ccache_lockfile(self):
         return '{}.krbticket.lock'.format(self.ccache_name)
 
+    @property
+    def ccache_cmd_lockfile(self):
+        return '{}.krbticket.cmd.lock'.format(self.ccache_name)
+
     def _per_process_ccache_name(self):
         if self._is_main_process():
             return self._default_ccache_name()

--- a/krbticket/updater.py
+++ b/krbticket/updater.py
@@ -70,8 +70,7 @@ class MultiProcessKrbTicketUpdater(KrbTicketUpdater):
     KrbTicketUpdater w/ exclusive lock for a ccache
     """
     def update(self):
-        with fasteners.InterProcessLock(self.ticket.config.ccache_lockfile):
-            self.ticket.maybe_update()
+        self.ticket.maybe_update()
 
     @staticmethod
     def use_per_process_ccache():

--- a/krbticket/updater.py
+++ b/krbticket/updater.py
@@ -17,6 +17,7 @@ class KrbTicketUpdater(threading.Thread):
         self.interval = interval
         self.stop_event = threading.Event()
         self.daemon = True
+        self.start_lock = threading.Lock()
 
     def run(self):
         logger.info("{} start...".format(self.__class__.__name__))
@@ -29,11 +30,12 @@ class KrbTicketUpdater(threading.Thread):
             time.sleep(self.interval)
 
     def start(self):
-        if self.is_alive():
-            logger.debug("Skipping Thread.start() since it already started...")
-            return
+        with self.start_lock:
+            if self.is_alive():
+                logger.debug("Skipping Thread.start() since it already started...")
+                return
 
-        super().start()
+            super().start()
 
     def update(self):
         raise NotImplementedError

--- a/krbticket/updater.py
+++ b/krbticket/updater.py
@@ -26,7 +26,7 @@ class KrbTicketUpdater(threading.Thread):
                 return
 
             logger.debug("Trying to update ticket...")
-            self.update()
+            self.ticket.maybe_update()
             time.sleep(self.interval)
 
     def start(self):
@@ -36,9 +36,6 @@ class KrbTicketUpdater(threading.Thread):
                 return
 
             super().start()
-
-    def update(self):
-        raise NotImplementedError
 
     @staticmethod
     def use_per_process_ccache():
@@ -55,9 +52,6 @@ class SimpleKrbTicketUpdater(KrbTicketUpdater):
 
     Using this with multiprocessing, child processes uses dedicated ccache file
     """
-    def update(self):
-        self.ticket.maybe_update()
-
     @staticmethod
     def use_per_process_ccache():
         return True
@@ -69,9 +63,6 @@ class MultiProcessKrbTicketUpdater(KrbTicketUpdater):
 
     KrbTicketUpdater w/ exclusive lock for a ccache
     """
-    def update(self):
-        self.ticket.maybe_update()
-
     @staticmethod
     def use_per_process_ccache():
         return False
@@ -98,9 +89,6 @@ class SingleProcessKrbTicketUpdater(KrbTicketUpdater):
             if got_lock:
                 lock.release()
                 logger.debug("Released lock: {}...".format(self.ticket.config.ccache_lockfile))
-
-    def update(self):
-        self.ticket.maybe_update()
 
     @staticmethod
     def use_per_process_ccache():

--- a/krbticket/updater.py
+++ b/krbticket/updater.py
@@ -35,6 +35,10 @@ class KrbTicketUpdater(threading.Thread):
                 logger.debug("Skipping Thread.start() since it already started...")
                 return
 
+            if self.stop_event.is_set():
+                logger.debug("Skipping Thread.start() since it already stopped...")
+                return
+
             super().start()
 
     @staticmethod
@@ -75,7 +79,7 @@ class SingleProcessKrbTicketUpdater(KrbTicketUpdater):
     Single Process KrbTicketUpdater on the system.
     Multiple updaters can start, but they immediately stops if a updater is already running on the system.
     """
-    def run(self):
+    def start(self):
         lock = fasteners.InterProcessLock(self.ticket.config.ccache_lockfile)
         got_lock = lock.acquire(blocking=False)
         if not got_lock:
@@ -84,7 +88,7 @@ class SingleProcessKrbTicketUpdater(KrbTicketUpdater):
 
         logger.debug("Got lock: {}...".format(self.ticket.config.ccache_lockfile))
         try:
-            super().run()
+            super().start()
         finally:
             if got_lock:
                 lock.release()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -31,8 +31,8 @@ def test_reuse_updater(config):
     updater.stop()
     time.sleep(2)
     assert not updater.is_alive()
-    with pytest.raises(RuntimeError):
-        updater.start()
+    updater.start()
+    assert not updater.is_alive()
 
 
 def test_updater_start(config):


### PR DESCRIPTION
- Exclusive lock for kinit/klist/kdestroy call per ccache
- allow multiple updater.start() call, and ignore it