### PR TITLE
Fix race conditions

### DIFF
--- a/krbticket/command.py
+++ b/krbticket/command.py
@@ -60,6 +60,11 @@ class KrbCommand():
         return KrbCommand._call(config, commands)
 
     @staticmethod
+    def cache_exists(config):
+        with fasteners.InterProcessLock(config.ccache_cmd_lockfile):
+            return os.path.isfile(config.ccache_name)
+
+    @staticmethod
     def _call(config, commands):
 
         def error_on_retry(exception):

--- a/krbticket/command.py
+++ b/krbticket/command.py
@@ -2,9 +2,13 @@ import fasteners
 import logging
 import os
 import subprocess
+import threading
 from retrying import retry
 
 logger = logging.getLogger(__name__)
+# fasteners is for interprocess multiprocessing
+# threading.Lock is for multithreading
+lock = threading.Lock()
 
 
 class KrbCommand():
@@ -61,8 +65,9 @@ class KrbCommand():
 
     @staticmethod
     def cache_exists(config):
-        with fasteners.InterProcessLock(config.ccache_cmd_lockfile):
-            return os.path.isfile(config.ccache_name)
+        with lock:
+            with fasteners.InterProcessLock(config.ccache_cmd_lockfile):
+                return os.path.isfile(config.ccache_name)
 
     @staticmethod
     def _call(config, commands):
@@ -83,5 +88,6 @@ class KrbCommand():
             custom_env["LC_ALL"] = "C"
             return subprocess.check_output(commands, universal_newlines=True, env=custom_env)
 
-        with fasteners.InterProcessLock(config.ccache_cmd_lockfile):
-            return retriable_call()
+        with lock:
+            with fasteners.InterProcessLock(config.ccache_cmd_lockfile):
+                return retriable_call()

--- a/krbticket/ticket.py
+++ b/krbticket/ticket.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 import logging
 import threading
@@ -81,9 +80,6 @@ class KrbTicket():
         else:
             return self.need_renewal()
 
-    def destroy(self):
-        KrbCommand.kdestroy(self.config)
-
     def __str__(self):
         super_str = super(KrbTicket, self).__str__()
         return "{}: file={}, principal={}, starting={}, expires={}," \
@@ -103,7 +99,7 @@ class KrbTicket():
 
     @staticmethod
     def cache_exists(config):
-        return os.path.isfile(config.ccache_name)
+        return KrbCommand.cache_exists(config)
 
     @staticmethod
     def init(principal, keytab=None, **kwargs):
@@ -172,5 +168,5 @@ class KrbTicket():
         with KrbTicket.__instances_lock__:
             for (key, ticket) in KrbTicket.__instances__.items():
                 ticket.updater().stop()
-                ticket.destroy()
+                KrbCommand.kdestroy(ticket.config)
             KrbTicket.__instances__ = {}

--- a/krbticket/ticket.py
+++ b/krbticket/ticket.py
@@ -81,6 +81,9 @@ class KrbTicket():
         else:
             return self.need_renewal()
 
+    def destroy(self):
+        KrbCommand.kdestroy(self.config)
+
     def __str__(self):
         super_str = super(KrbTicket, self).__str__()
         return "{}: file={}, principal={}, starting={}, expires={}," \
@@ -158,3 +161,16 @@ class KrbTicket():
             expires=parseDatetime(expires),
             service_principal=service_principal,
             renew_expires=parseDatetime(renew_expires))
+
+    @staticmethod
+    def _destroy():
+        """
+        destroy internal ticket registry
+
+        stop all updaters belonging to a ticket registered in registry, and remove all entiries
+        """
+        with KrbTicket.__instances_lock__:
+            for (key, ticket) in KrbTicket.__instances__.items():
+                ticket.updater().stop()
+                ticket.destroy()
+            KrbTicket.__instances__ = {}

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -4,6 +4,9 @@ from datetime import datetime
 import os
 import subprocess
 
+def teardown_function(function):
+    KrbTicket._destroy()
+
 
 def test_init(config):
     KrbCommand.kdestroy(config)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 
 def teardown_function(function):
-    KrbTicket.__instances__ = {}
+    KrbTicket._destroy()
 
 
 def test_updater(config):


### PR DESCRIPTION
- test: Remove unused old ticket and updater in teardown_function
- Fix the race condition of file existence check w/ kinit
- prepare a lock to krbcommand  for multithreading